### PR TITLE
Change default grid layout to 2x3

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -185,7 +185,7 @@ export function getDefaultPreferences(): AppPreferences {
     attentionMode: 'focus',
     operatingMode: 'solo',
     agentModel: 'sonnet',
-    gridSize: '2x2',
+    gridSize: '2x3',
     keyboardShortcuts: getDefaultKeyboardShortcuts(),
   }
 }
@@ -303,9 +303,9 @@ export function loadState(): AppState {
       state.preferences.agentModel = 'sonnet'
       needsSave = true
     }
-    // Migration: add gridSize if missing (default to '2x2')
+    // Migration: add gridSize if missing (default to '2x3')
     if (!state.preferences.gridSize) {
-      state.preferences.gridSize = '2x2'
+      state.preferences.gridSize = '2x3'
       needsSave = true
     }
     // Migration: add keyboardShortcuts if missing

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -134,7 +134,7 @@ function App() {
     attentionMode: 'focus',
     operatingMode: 'solo',
     agentModel: 'sonnet',
-    gridSize: '2x2',
+    gridSize: '2x3',
   })
   const [preferencesLoaded, setPreferencesLoaded] = useState(false)
 


### PR DESCRIPTION
Updated default gridSize from 2x2 to 2x3 to provide more agent slots by default. This includes changes to config.ts, App.tsx, and migration logic.