### PR TITLE
bismarck-xfd: Fix persona changes not applying in installed app

### DIFF
--- a/src/main/hook-manager.ts
+++ b/src/main/hook-manager.ts
@@ -252,8 +252,9 @@ export function configureClaudeHook(): void {
   let settingsChanged = false
 
   // Configure Stop hook
+  // Check for EXACT path match to ensure dev/prod hooks don't conflict
   const stopHookExists = settings.hooks.Stop?.some((config) =>
-    config.hooks.some((hook) => hook.command.includes('bismarck'))
+    config.hooks.some((hook) => hook.command === hookScriptPath)
   )
 
   if (!stopHookExists) {
@@ -278,8 +279,9 @@ export function configureClaudeHook(): void {
   }
 
   // Configure Notification hook for permission prompts
+  // Check for EXACT path match to ensure dev/prod hooks don't conflict
   const notificationHookExists = settings.hooks.Notification?.some((config) =>
-    config.hooks.some((hook) => hook.command.includes('bismarck'))
+    config.hooks.some((hook) => hook.command === notificationHookScriptPath)
   )
 
   if (!notificationHookExists) {
@@ -302,8 +304,9 @@ export function configureClaudeHook(): void {
   }
 
   // Configure SessionStart hook to create session-to-workspace mapping
+  // Check for EXACT path match to ensure dev/prod hooks don't conflict
   const sessionStartHookExists = settings.hooks.SessionStart?.some((config) =>
-    config.hooks.some((hook) => hook.command.includes('bismarck'))
+    config.hooks.some((hook) => hook.command === sessionStartHookScriptPath)
   )
 
   if (!sessionStartHookExists) {
@@ -325,9 +328,9 @@ export function configureClaudeHook(): void {
   }
 
   // Configure UserPromptSubmit hook for Persona Mode (unified)
-  // Check for new persona-mode-hook (preferred) or old bismarck-mode-hook/otto-mode-hook
+  // Check for EXACT path match to ensure dev/prod hooks don't conflict
   const personaModeHookExists = settings.hooks.UserPromptSubmit?.some((config) =>
-    config.hooks.some((hook) => hook.command.includes('persona-mode-hook'))
+    config.hooks.some((hook) => hook.command === personaModeHookScriptPath)
   )
 
   if (!personaModeHookExists) {
@@ -372,6 +375,10 @@ export function configureClaudeHook(): void {
 
 export function isHookConfigured(): boolean {
   const settingsPath = getClaudeSettingsPath()
+  const hookScriptPath = getHookScriptPath()
+  const notificationHookScriptPath = getNotificationHookScriptPath()
+  const sessionStartHookScriptPath = getSessionStartHookScriptPath()
+  const personaModeHookScriptPath = getPersonaModeHookScriptPath()
 
   if (!fs.existsSync(settingsPath)) {
     return false
@@ -381,24 +388,25 @@ export function isHookConfigured(): boolean {
     const content = fs.readFileSync(settingsPath, 'utf-8')
     const settings = JSON.parse(content) as ClaudeSettings
 
+    // Check for EXACT path match to ensure dev/prod hooks don't conflict
     const stopHookExists =
       settings.hooks?.Stop?.some((config) =>
-        config.hooks.some((hook) => hook.command.includes('bismarck'))
+        config.hooks.some((hook) => hook.command === hookScriptPath)
       ) ?? false
 
     const notificationHookExists =
       settings.hooks?.Notification?.some((config) =>
-        config.hooks.some((hook) => hook.command.includes('bismarck'))
+        config.hooks.some((hook) => hook.command === notificationHookScriptPath)
       ) ?? false
 
     const sessionStartHookExists =
       settings.hooks?.SessionStart?.some((config) =>
-        config.hooks.some((hook) => hook.command.includes('bismarck'))
+        config.hooks.some((hook) => hook.command === sessionStartHookScriptPath)
       ) ?? false
 
     const personaModeHookExists =
       settings.hooks?.UserPromptSubmit?.some((config) =>
-        config.hooks.some((hook) => hook.command.includes('persona-mode-hook'))
+        config.hooks.some((hook) => hook.command === personaModeHookScriptPath)
       ) ?? false
 
     return stopHookExists && notificationHookExists && sessionStartHookExists && personaModeHookExists


### PR DESCRIPTION
Fix hook registration to use exact path matching for dev/prod isolation. The hook checks were using substring matching which caused dev and prod hooks to conflict when both modes were used.