### PR TITLE
Add BuildBuddy (bb) as a proxied tool

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,11 @@ RUN chmod +x /usr/local/bin/bd
 COPY git-proxy-wrapper.sh /usr/local/bin/git
 RUN chmod +x /usr/local/bin/git
 
+# Copy bb CLI wrapper that calls the tool proxy
+# This proxies bb (BuildBuddy) commands to the host where SSO auth lives
+COPY bb-proxy-wrapper.sh /usr/local/bin/bb
+RUN chmod +x /usr/local/bin/bb
+
 # Create non-root user (Claude refuses --dangerously-skip-permissions as root)
 RUN useradd -m -s /bin/bash agent && \
     mkdir -p /workspace /plan && \

--- a/docker/bb-proxy-wrapper.sh
+++ b/docker/bb-proxy-wrapper.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# bb CLI proxy wrapper for Bismarck containers
+#
+# Instead of running bb directly (which would require host-side SSO auth),
+# this script proxies all bb commands to the Bismarck tool proxy server
+# running on the host.
+#
+# Usage: bb view //target --flag
+# All arguments are forwarded as-is to the host's bb binary.
+
+set -e
+
+# Get proxy URL and host worktree path from environment (set by docker run)
+PROXY_URL="${TOOL_PROXY_URL:-http://host.docker.internal:9847}"
+HOST_CWD="${BISMARCK_HOST_WORKTREE_PATH:-}"
+
+# Build JSON payload with all arguments
+ARGS_JSON=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+
+# Build request body
+if [ -n "$HOST_CWD" ]; then
+  BODY="{\"args\": ${ARGS_JSON}, \"cwd\": \"${HOST_CWD}\"}"
+else
+  BODY="{\"args\": ${ARGS_JSON}}"
+fi
+
+# Make request to proxy
+RESPONSE=$(curl -s -X POST "${PROXY_URL}/bb" \
+  -H "Content-Type: application/json" \
+  -d "$BODY")
+
+# Extract fields from response
+SUCCESS=$(echo "$RESPONSE" | jq -r '.success')
+STDOUT=$(echo "$RESPONSE" | jq -r '.stdout // empty')
+STDERR=$(echo "$RESPONSE" | jq -r '.stderr // empty')
+EXIT_CODE=$(echo "$RESPONSE" | jq -r '.exitCode // 1')
+
+# Output results
+if [ -n "$STDOUT" ]; then
+  echo "$STDOUT"
+fi
+
+if [ -n "$STDERR" ]; then
+  echo "$STDERR" >&2
+fi
+
+# Exit with same code as proxied command
+exit "$EXIT_CODE"

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -482,7 +482,7 @@ export const logger = {
    * Log proxy requests
    */
   proxyRequest(
-    tool: 'gh' | 'bd' | 'git',
+    tool: 'gh' | 'bd' | 'git' | 'bb',
     args: string[],
     success: boolean,
     context?: LogContext,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -388,6 +388,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('detect-tool-paths'),
   toggleProxiedTool: (id: string, enabled: boolean) =>
     ipcRenderer.invoke('toggle-proxied-tool', id, enabled),
+  getToolAuthStatuses: () =>
+    ipcRenderer.invoke('get-tool-auth-statuses'),
+  checkToolAuth: () =>
+    ipcRenderer.invoke('check-tool-auth'),
+  onToolAuthStatus: (callback: (statuses: Array<{ toolId: string; toolName: string; state: string; reauthHint?: string; message?: string }>) => void): void => {
+    ipcRenderer.removeAllListeners('tool-auth-status')
+    ipcRenderer.on('tool-auth-status', (_event, statuses) => callback(statuses))
+  },
+  removeToolAuthStatusListener: (): void => {
+    ipcRenderer.removeAllListeners('tool-auth-status')
+  },
   updateDockerSshSettings: (settings: { enabled?: boolean }) =>
     ipcRenderer.invoke('update-docker-ssh-settings', settings),
   updateDockerSocketSettings: (settings: { enabled?: boolean; path?: string }) =>
@@ -510,6 +521,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.removeAllListeners('setup-terminal-exit')
     ipcRenderer.removeAllListeners('update-status')
     ipcRenderer.removeAllListeners('docker-pull-progress')
+    ipcRenderer.removeAllListeners('tool-auth-status')
   },
 
   // Dev test harness (development mode only)

--- a/src/main/prompt-templates.ts
+++ b/src/main/prompt-templates.ts
@@ -597,7 +597,7 @@ export async function getPromptTemplate(type: PromptType): Promise<string> {
 /**
  * Build the PROXIED COMMANDS section based on which tools are enabled
  */
-export function buildProxiedToolsSection(enabledTools: { git: boolean; gh: boolean; bd: boolean }): string {
+export function buildProxiedToolsSection(enabledTools: { git: boolean; gh: boolean; bd: boolean; bb?: boolean }): string {
   const sections: string[] = []
   let num = 1
 
@@ -620,6 +620,13 @@ export function buildProxiedToolsSection(enabledTools: { git: boolean; gh: boole
     sections.push(`${num}. Beads Task Management (bd):
    - bd list, bd ready, bd show, bd close, bd update
    - The --sandbox flag is added automatically`)
+    num++
+  }
+
+  if (enabledTools.bb) {
+    sections.push(`${num}. BuildBuddy CLI (bb):
+   - bb view, bb run, bb test, bb remote
+   - All standard bb commands work`)
   }
 
   if (sections.length === 0) {

--- a/src/main/ralph-loop.ts
+++ b/src/main/ralph-loop.ts
@@ -231,7 +231,7 @@ function buildRalphLoopPrompt(
   iterationNumber: number,
   maxIterations: number,
   completionPhrase: string,
-  enabledTools: { git: boolean; gh: boolean; bd: boolean }
+  enabledTools: { git: boolean; gh: boolean; bd: boolean; bb?: boolean }
 ): string {
   const proxiedToolsSection = buildProxiedToolsSection(enabledTools)
 
@@ -521,6 +521,7 @@ async function runIteration(state: RalphLoopState, iterationNumber: number): Pro
       git: proxiedTools.find(t => t.name === 'git')?.enabled ?? true,
       gh: proxiedTools.find(t => t.name === 'gh')?.enabled ?? true,
       bd: proxiedTools.find(t => t.name === 'bd')?.enabled ?? true,
+      bb: proxiedTools.find(t => t.name === 'bb')?.enabled ?? false,
     }
     const enhancedPrompt = buildRalphLoopPrompt(
       state.config.prompt,

--- a/src/main/standalone-headless.ts
+++ b/src/main/standalone-headless.ts
@@ -177,6 +177,7 @@ Keep iterating until all criteria are satisfied.
     git: proxiedTools.find(t => t.name === 'git')?.enabled ?? true,
     gh: proxiedTools.find(t => t.name === 'gh')?.enabled ?? true,
     bd: proxiedTools.find(t => t.name === 'bd')?.enabled ?? true,
+    bb: proxiedTools.find(t => t.name === 'bb')?.enabled ?? false,
   })
 
   const variables: PromptVariables = {
@@ -226,6 +227,7 @@ Keep iterating until all criteria are satisfied.
     git: proxiedTools.find(t => t.name === 'git')?.enabled ?? true,
     gh: proxiedTools.find(t => t.name === 'gh')?.enabled ?? true,
     bd: proxiedTools.find(t => t.name === 'bd')?.enabled ?? true,
+    bb: proxiedTools.find(t => t.name === 'bb')?.enabled ?? false,
   })
 
   const variables: PromptVariables = {

--- a/src/main/tool-auth-checker.ts
+++ b/src/main/tool-auth-checker.ts
@@ -1,0 +1,179 @@
+/**
+ * Tool Auth Checker
+ *
+ * Generic periodic auth checker for any proxied tool with an `authCheck` config.
+ * Checks auth status by running the configured command and mapping exit codes:
+ *   0 = valid, 1 = needs reauth, anything else = error
+ *
+ * Pushes status updates to the renderer via IPC.
+ */
+
+import { BrowserWindow } from 'electron'
+import { logger } from './logger'
+import { loadSettings, type ProxiedTool } from './settings-manager'
+import { spawnWithPath } from './exec-utils'
+
+export interface ToolAuthStatus {
+  toolId: string
+  toolName: string
+  state: 'valid' | 'needs-reauth' | 'error'
+  reauthHint?: string
+  message?: string
+}
+
+let mainWindow: BrowserWindow | null = null
+let checkInterval: ReturnType<typeof setInterval> | null = null
+let initialCheckTimeout: ReturnType<typeof setTimeout> | null = null
+let currentStatuses: ToolAuthStatus[] = []
+
+/**
+ * Set the main window reference for pushing status updates
+ */
+export function setAuthCheckerWindow(window: BrowserWindow | null): void {
+  mainWindow = window
+}
+
+/**
+ * Check auth for a single proxied tool
+ */
+export async function checkToolAuth(tool: ProxiedTool): Promise<ToolAuthStatus> {
+  if (!tool.authCheck) {
+    return { toolId: tool.id, toolName: tool.name, state: 'valid' }
+  }
+
+  const [command, ...args] = tool.authCheck.command
+
+  return new Promise((resolve) => {
+    try {
+      const proc = spawnWithPath(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: false,
+        timeout: 10000,
+      })
+
+      let stderr = ''
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString()
+      })
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve({ toolId: tool.id, toolName: tool.name, state: 'valid' })
+        } else if (code === 1) {
+          resolve({
+            toolId: tool.id,
+            toolName: tool.name,
+            state: 'needs-reauth',
+            reauthHint: tool.authCheck!.reauthHint,
+          })
+        } else {
+          resolve({
+            toolId: tool.id,
+            toolName: tool.name,
+            state: 'error',
+            message: stderr.trim() || `Auth check exited with code ${code}`,
+          })
+        }
+      })
+
+      proc.on('error', (err) => {
+        resolve({
+          toolId: tool.id,
+          toolName: tool.name,
+          state: 'error',
+          message: err.message,
+        })
+      })
+    } catch (err) {
+      resolve({
+        toolId: tool.id,
+        toolName: tool.name,
+        state: 'error',
+        message: err instanceof Error ? err.message : 'Unknown error',
+      })
+    }
+  })
+}
+
+/**
+ * Check auth for all enabled proxied tools that have authCheck configured
+ */
+export async function checkAllToolAuth(): Promise<ToolAuthStatus[]> {
+  const settings = await loadSettings()
+  const toolsWithAuth = settings.docker.proxiedTools.filter(
+    t => t.enabled && t.authCheck
+  )
+
+  if (toolsWithAuth.length === 0) {
+    currentStatuses = []
+    pushStatusToRenderer()
+    return []
+  }
+
+  const statuses = await Promise.all(toolsWithAuth.map(checkToolAuth))
+  currentStatuses = statuses
+  pushStatusToRenderer()
+
+  // Log any tools needing reauth
+  for (const status of statuses) {
+    if (status.state === 'needs-reauth') {
+      logger.info('proxy', `${status.toolName}: needs re-authentication`)
+    } else if (status.state === 'error') {
+      logger.warn('proxy', `${status.toolName}: auth check error - ${status.message}`)
+    }
+  }
+
+  return statuses
+}
+
+/**
+ * Get current auth statuses (cached from last check)
+ */
+export function getToolAuthStatuses(): ToolAuthStatus[] {
+  return [...currentStatuses]
+}
+
+/**
+ * Push current statuses to renderer via IPC
+ */
+function pushStatusToRenderer(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('tool-auth-status', currentStatuses)
+  }
+}
+
+/**
+ * Start periodic auth checks
+ * Initial check after 3s, then every 5 minutes
+ */
+export function startToolAuthChecks(): void {
+  stopToolAuthChecks()
+
+  // Initial check after 3 seconds
+  initialCheckTimeout = setTimeout(() => {
+    checkAllToolAuth().catch(err => {
+      logger.error('proxy', `Initial check failed: ${err}`)
+    })
+  }, 3000)
+
+  // Periodic checks every 5 minutes
+  checkInterval = setInterval(() => {
+    checkAllToolAuth().catch(err => {
+      logger.error('proxy', `Periodic check failed: ${err}`)
+    })
+  }, 5 * 60 * 1000)
+}
+
+/**
+ * Stop periodic auth checks
+ */
+export function stopToolAuthChecks(): void {
+  if (initialCheckTimeout) {
+    clearTimeout(initialCheckTimeout)
+    initialCheckTimeout = null
+  }
+  if (checkInterval) {
+    clearInterval(checkInterval)
+    checkInterval = null
+  }
+}

--- a/src/main/tool-proxy.ts
+++ b/src/main/tool-proxy.ts
@@ -27,6 +27,7 @@ export interface ToolProxyConfig {
     gh: { enabled: boolean }
     bd: { enabled: boolean }
     git: { enabled: boolean }
+    bb: { enabled: boolean }
   }
 }
 
@@ -36,6 +37,7 @@ const DEFAULT_CONFIG: ToolProxyConfig = {
     gh: { enabled: true },
     bd: { enabled: true },
     git: { enabled: true },
+    bb: { enabled: false },
   },
 }
 
@@ -413,6 +415,53 @@ async function handleGitRequest(
 }
 
 /**
+ * Handle bb CLI proxy requests
+ */
+async function handleBbRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+): Promise<void> {
+  if (!currentConfig.tools.bb.enabled) {
+    logger.warn('proxy', 'bb tool is disabled, rejecting request')
+    sendJson(res, 403, { success: false, error: 'bb tool is disabled' })
+    return
+  }
+
+  try {
+    const body = (await parseBody(req)) as ProxyRequest & { cwd?: string }
+
+    const args = body.args || []
+    const cwd = body.cwd
+
+    logger.debug('proxy', `bb request: ${args.join(' ')}`, cwd ? { worktreePath: cwd } : undefined)
+
+    // Log the operation
+    proxyEvents.emit('bb', { args, cwd })
+
+    const result = await executeCommand('bb', args, body.stdin, { cwd })
+
+    logger.proxyRequest('bb', args, result.exitCode === 0, undefined, {
+      exitCode: result.exitCode,
+      stderrPreview: result.stderr?.substring(0, 100),
+    })
+
+    sendJson(res, 200, {
+      success: result.exitCode === 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    })
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : 'Unknown error'
+    logger.error('proxy', `bb request failed: ${errorMsg}`)
+    sendJson(res, 400, {
+      success: false,
+      error: errorMsg,
+    })
+  }
+}
+
+/**
  * Handle health check requests
  */
 function handleHealthCheck(res: http.ServerResponse): void {
@@ -451,6 +500,8 @@ async function handleRequest(
     await handleBdRequest(req, res)
   } else if (url.startsWith('/git') && method === 'POST') {
     await handleGitRequest(req, res)
+  } else if (url.startsWith('/bb') && method === 'POST') {
+    await handleBbRequest(req, res)
   } else {
     sendJson(res, 404, { success: false, error: 'Not found' })
   }
@@ -472,6 +523,7 @@ export async function startToolProxy(config: Partial<ToolProxyConfig> = {}): Pro
     gh: { enabled: proxiedTools.find(t => t.name === 'gh')?.enabled ?? true },
     bd: { enabled: proxiedTools.find(t => t.name === 'bd')?.enabled ?? true },
     git: { enabled: proxiedTools.find(t => t.name === 'git')?.enabled ?? true },
+    bb: { enabled: proxiedTools.find(t => t.name === 'bb')?.enabled ?? false },
   }
 
   // Find available port if not explicitly specified
@@ -502,6 +554,7 @@ export async function startToolProxy(config: Partial<ToolProxyConfig> = {}): Pro
         ghEnabled: currentConfig.tools.gh.enabled,
         bdEnabled: currentConfig.tools.bd.enabled,
         gitEnabled: currentConfig.tools.git.enabled,
+        bbEnabled: currentConfig.tools.bb.enabled,
       })
       proxyEvents.emit('started', { port: currentConfig.port })
       resolve()

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,6 +1,15 @@
 import type { Workspace, AppState, AgentTab, AppPreferences, Plan, TaskAssignment, PlanActivity, Repository, HeadlessAgentInfo, StreamEvent, BranchStrategy, BeadTask, PromptType, DiscoveredRepo, RalphLoopConfig, RalphLoopState, DescriptionProgressEvent, DiffResult, FileDiffContent } from '../shared/types'
 import type { AppSettings, ProxiedTool } from '../main/settings-manager'
 
+// Tool auth status from the auth checker
+export interface ToolAuthStatus {
+  toolId: string
+  toolName: string
+  state: 'valid' | 'needs-reauth' | 'error'
+  reauthHint?: string
+  message?: string
+}
+
 // Update status types
 export type UpdateStatus =
   | { state: 'idle' }
@@ -185,6 +194,10 @@ export interface ElectronAPI {
   updateToolPaths: (paths: { bd?: string | null; gh?: string | null; git?: string | null }) => Promise<void>
   detectToolPaths: () => Promise<{ bd: string | null; gh: string | null; git: string | null }>
   toggleProxiedTool: (id: string, enabled: boolean) => Promise<ProxiedTool | undefined>
+  getToolAuthStatuses: () => Promise<ToolAuthStatus[]>
+  checkToolAuth: () => Promise<ToolAuthStatus[]>
+  onToolAuthStatus: (callback: (statuses: ToolAuthStatus[]) => void) => void
+  removeToolAuthStatusListener: () => void
   updateDockerSshSettings: (settings: { enabled?: boolean }) => Promise<void>
   updateDockerSocketSettings: (settings: { enabled?: boolean; path?: string }) => Promise<void>
   setRawSettings: (settings: unknown) => Promise<AppSettings>


### PR DESCRIPTION
## Summary

- Adds `bb` (BuildBuddy CLI) as a new proxied tool, disabled by default
- Builds a generic auth-checking mechanism on `ProxiedTool` — any tool with an `authCheck` config gets periodic SSO validation (initial check after 3s, then every 5 min)
- Shows a yellow header banner when tools need re-authentication, with click-through to Settings
- Settings > Tools shows auth status badges (green/yellow/gray) and inline reauth hints with a "Check Now" button
- Includes Docker wrapper, proxy route, prompt template support, and settings migration for existing users

## Test plan

- [ ] Toggle bb on/off in Settings — verify settings persist and proxy reacts (403 when disabled)
- [ ] With bb enabled, launch a headless agent — verify prompt includes bb section
- [ ] With bb disabled, verify prompt omits bb
- [ ] Simulate expired auth — verify yellow banner appears with correct hint text
- [ ] After re-auth, click "Check Now" — verify banner clears
- [ ] Existing user migration: verify bb auto-added as disabled to existing settings
- [ ] Confirm git/gh/bd are unaffected (no authCheck, no status badges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)