### PR TITLE
fix: Reuse React root on HMR to prevent double createRoot() warning

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -21,9 +21,16 @@ export function sendMilestone(name: string): void {
 const importEndTime = performance.now()
 sendTiming('renderer:imports', 0, importEndTime - rendererStartTime)
 
-// Time createRoot
+// Reuse existing root on HMR to avoid "createRoot() on a container that has
+// already been passed to createRoot()" warning.
+const container = document.getElementById('root')!
+const existingRoot = (container as any).__reactRoot
+
 const createRootStart = performance.now()
-const root = ReactDOM.createRoot(document.getElementById('root')!)
+const root = existingRoot ?? ReactDOM.createRoot(container)
+if (!existingRoot) {
+  ;(container as any).__reactRoot = root
+}
 sendTiming('renderer:createRoot', createRootStart - rendererStartTime, performance.now() - createRootStart)
 
 // Time render


### PR DESCRIPTION
## Summary

- Fixes the `ReactDOMClient.createRoot()` warning that fires during Vite HMR when the module re-executes on an already-rooted container
- Stores the root instance on the container DOM element and reuses it on subsequent module executions

## Test plan

- [ ] Run `npm run dev` and edit a renderer file to trigger HMR — verify no `createRoot()` warning in console
- [ ] Cold start still works correctly
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)