### PR TITLE
feat: Add standalone terminals via CMD-K

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -125,6 +125,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   destroyHeadlessAgent: (taskId: string, isStandalone: boolean): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('destroy-headless-agent', taskId, isStandalone),
 
+  // Standalone terminal management
+  createStandaloneTerminal: (tabId?: string): Promise<{ workspaceId: string; terminalId: string; tabId: string }> =>
+    ipcRenderer.invoke('create-standalone-terminal', tabId),
+  closeStandaloneTerminal: (workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke('close-standalone-terminal', workspaceId),
+
   // Standalone headless agent management
   startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet', tabId?: string): Promise<{ headlessId: string; workspaceId: string; tabId: string }> =>
     ipcRenderer.invoke('start-standalone-headless-agent', agentId, prompt, model, tabId),

--- a/src/main/standalone-terminal.ts
+++ b/src/main/standalone-terminal.ts
@@ -1,0 +1,131 @@
+/**
+ * Standalone Terminal
+ *
+ * Manages standalone terminals (plain shell, no Claude) that occupy workspace grid slots.
+ * Created via CMD-K "Add Terminal" command.
+ */
+
+import * as os from 'os'
+import { BrowserWindow } from 'electron'
+import { randomUUID } from 'crypto'
+import { devLog } from './dev-log'
+import {
+  saveWorkspace,
+  deleteWorkspace,
+  getRandomUniqueIcon,
+  getWorkspaces,
+} from './config'
+import {
+  getOrCreateTabForWorkspaceWithPreference,
+  addWorkspaceToTab,
+  setActiveTab,
+  addActiveWorkspace,
+  removeActiveWorkspace,
+  removeWorkspaceFromTab,
+} from './state-manager'
+import { createPlainTerminal, closeTerminal, getTerminalForWorkspace } from './terminal'
+import type { Agent, ThemeName } from '../shared/types'
+
+// Word lists for fun random names (shared style with standalone-headless)
+const ADJECTIVES = [
+  'fluffy', 'happy', 'brave', 'swift', 'clever', 'gentle', 'mighty', 'calm',
+  'wild', 'eager', 'jolly', 'lucky', 'plucky', 'zesty', 'snappy', 'peppy'
+]
+
+const NOUNS = [
+  'bunny', 'panda', 'koala', 'otter', 'falcon', 'dolphin', 'fox', 'owl',
+  'tiger', 'eagle', 'wolf', 'bear', 'hawk', 'lynx', 'raven', 'seal'
+]
+
+const THEMES: ThemeName[] = ['gray', 'teal', 'blue', 'green', 'purple', 'orange', 'pink', 'red', 'brown']
+
+function generateRandomPhrase(): string {
+  const adjective = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)]
+  const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)]
+  return `${adjective}-${noun}`
+}
+
+let mainWindow: BrowserWindow | null = null
+
+export function setMainWindowForStandaloneTerminal(window: BrowserWindow | null): void {
+  mainWindow = window
+}
+
+function emitStateUpdate(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    const { getState } = require('./state-manager')
+    mainWindow.webContents.send('state-update', getState())
+  }
+}
+
+/**
+ * Create a standalone terminal workspace and spawn a plain shell.
+ * Returns { workspaceId, terminalId, tabId }
+ */
+export function createStandaloneTerminal(
+  targetTabId?: string,
+  directory?: string
+): { workspaceId: string; terminalId: string; tabId: string } {
+  const workspaceId = randomUUID()
+  const phrase = generateRandomPhrase()
+  const cwd = directory || os.homedir()
+  const theme = THEMES[Math.floor(Math.random() * THEMES.length)]
+
+  const existingWorkspaces = getWorkspaces()
+  const newAgent: Agent = {
+    id: workspaceId,
+    name: `terminal: ${phrase}`,
+    directory: cwd,
+    purpose: 'Plain shell terminal',
+    theme,
+    icon: getRandomUniqueIcon(existingWorkspaces),
+    isStandaloneTerminal: true,
+  }
+
+  // Save the workspace
+  saveWorkspace(newAgent)
+
+  // Add to active workspaces and place in grid
+  addActiveWorkspace(workspaceId)
+  const tab = getOrCreateTabForWorkspaceWithPreference(workspaceId, targetTabId)
+  addWorkspaceToTab(workspaceId, tab.id)
+  setActiveTab(tab.id)
+
+  // Spawn the plain shell terminal
+  const terminalId = createPlainTerminal(workspaceId, mainWindow, cwd)
+
+  devLog(`[StandaloneTerminal] Created terminal: ${phrase} (${workspaceId}) in tab ${tab.id}`)
+
+  // Emit state update so renderer picks up the new workspace
+  emitStateUpdate()
+
+  // Notify renderer of the new terminal
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('terminal-created', { terminalId, workspaceId })
+  }
+
+  return { workspaceId, terminalId, tabId: tab.id }
+}
+
+/**
+ * Close and clean up a standalone terminal.
+ */
+export function closeStandaloneTerminal(workspaceId: string): void {
+  // Close the PTY terminal if running
+  const terminalId = getTerminalForWorkspace(workspaceId)
+  if (terminalId) {
+    closeTerminal(terminalId)
+  }
+
+  // Remove from grid and active workspaces
+  removeWorkspaceFromTab(workspaceId)
+  removeActiveWorkspace(workspaceId)
+
+  // Delete the workspace entry
+  deleteWorkspace(workspaceId)
+
+  devLog(`[StandaloneTerminal] Closed terminal: ${workspaceId}`)
+
+  // Emit state update
+  emitStateUpdate()
+}

--- a/src/renderer/components/CommandSearch.tsx
+++ b/src/renderer/components/CommandSearch.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
-import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare } from 'lucide-react'
+import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare, TerminalSquare } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -28,6 +28,7 @@ interface Command {
 }
 
 const commands: Command[] = [
+  { id: 'add-terminal', label: 'Add Terminal', icon: TerminalSquare },
   { id: 'start-headless', label: 'Start: Headless Agent', icon: Container },
   { id: 'start-headless-discussion', label: 'Discuss: Headless Agent', icon: MessageSquare },
   { id: 'start-ralph-loop', label: 'Start: Ralph Loop', icon: RefreshCw },
@@ -47,6 +48,7 @@ interface CommandSearchProps {
   onStartHeadless?: (agentId: string, prompt: string, model: 'opus' | 'sonnet') => void
   onStartHeadlessDiscussion?: (agentId: string, initialPrompt: string) => void
   onStartRalphLoopDiscussion?: (agentId: string, initialPrompt: string) => void
+  onAddTerminal?: () => void
   onStartPlan?: () => void
   onStartRalphLoop?: (config: RalphLoopConfig) => void
   prefillRalphLoopConfig?: {
@@ -67,6 +69,7 @@ export function CommandSearch({
   tabs,
   onSelectAgent,
   onStartHeadless,
+  onAddTerminal,
   onStartHeadlessDiscussion,
   onStartRalphLoopDiscussion,
   onStartPlan,
@@ -102,7 +105,8 @@ export function CommandSearch({
       !agent.isPlanAgent &&
       !agent.parentPlanId &&
       !agent.isHeadless &&
-      !agent.isStandaloneHeadless
+      !agent.isStandaloneHeadless &&
+      !agent.isStandaloneTerminal
     )
   }, [agents])
 
@@ -326,7 +330,10 @@ export function CommandSearch({
       // Check if selecting a command or an agent
       if (idx < filteredCommands.length) {
         const command = filteredCommands[idx]
-        if (command.id === 'start-headless') {
+        if (command.id === 'add-terminal') {
+          onAddTerminal?.()
+          onOpenChange(false)
+        } else if (command.id === 'start-headless') {
           setPendingCommand('headless')
           setMode('agent-select')
           setQuery('')

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -100,6 +100,10 @@ export interface ElectronAPI {
   stopHeadlessAgent: (taskId: string) => Promise<void>
   destroyHeadlessAgent: (taskId: string, isStandalone: boolean) => Promise<{ success: boolean; error?: string }>
 
+  // Standalone terminal management
+  createStandaloneTerminal: (tabId?: string) => Promise<{ workspaceId: string; terminalId: string; tabId: string }>
+  closeStandaloneTerminal: (workspaceId: string) => Promise<void>
+
   // Standalone headless agent management
   startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet' | 'haiku', tabId?: string) => Promise<{ headlessId: string; workspaceId: string; tabId: string }>
   getStandaloneHeadlessAgents: () => Promise<HeadlessAgentInfo[]>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,7 @@ export interface Agent {
   taskId?: string               // Associated task ID
   isHeadless?: boolean          // Running in headless Docker mode (no interactive terminal)
   isStandaloneHeadless?: boolean // Standalone headless agent (not part of a plan)
+  isStandaloneTerminal?: boolean // Standalone terminal (plain shell, no Claude)
   order?: number                 // Display order in sidebar (lower = higher in list)
 }
 


### PR DESCRIPTION
Adds standalone plain-shell terminals that occupy workspace grid slots, created via CMD-K Add Terminal command. Terminals spawn the user shell (bash/zsh) with no Claude CLI, using fun random names like terminal: eager-falcon. Full lifecycle management with proper close/delete cleanup.