### PR TITLE
feat: Add terminal-only agents via CMD-K

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -27,6 +27,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('close-terminal', terminalId),
   stopWorkspace: (workspaceId: string): Promise<void> =>
     ipcRenderer.invoke('stop-workspace', workspaceId),
+  createTerminalAgent: (name: string, directory: string): Promise<{ agentId: string; terminalId: string }> =>
+    ipcRenderer.invoke('create-terminal-agent', name, directory),
 
   // State management
   getState: (): Promise<AppState> => ipcRenderer.invoke('get-state'),

--- a/src/main/terminal.ts
+++ b/src/main/terminal.ts
@@ -304,6 +304,72 @@ export function createTerminal(
   return terminalId
 }
 
+/**
+ * Create a plain terminal (shell only, no Claude auto-start).
+ * Used for terminal-only agents that just provide a shell session.
+ */
+export function createPlainTerminal(
+  workspaceId: string,
+  mainWindow: BrowserWindow | null
+): string {
+  const workspace = getWorkspaceById(workspaceId)
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`)
+  }
+
+  const terminalId = `terminal-${workspaceId}-${Date.now()}`
+  const shell = process.env.SHELL || '/bin/zsh'
+
+  // Validate directory exists, fall back to home if not
+  let cwd = workspace.directory
+  if (!fs.existsSync(cwd)) {
+    console.warn(`Directory ${cwd} does not exist, using home directory`)
+    cwd = os.homedir()
+  }
+
+  // Spawn interactive shell (no Claude)
+  const ptyProcess = pty.spawn(shell, ['-l'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 30,
+    cwd,
+    env: {
+      ...process.env,
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+      BISMARCK_WORKSPACE_ID: workspaceId,
+      BISMARCK_INSTANCE_ID: getInstanceId(),
+    },
+  })
+
+  // Create emitter for terminal output listening
+  const emitter = new EventEmitter()
+
+  terminals.set(terminalId, {
+    pty: ptyProcess,
+    workspaceId,
+    emitter,
+  })
+
+  // Forward data to renderer and emit for listeners
+  ptyProcess.onData((data) => {
+    emitter.emit('data', data)
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('terminal-data', terminalId, data)
+    }
+  })
+
+  // Handle process exit
+  ptyProcess.onExit(({ exitCode }) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('terminal-exit', terminalId, exitCode)
+    }
+    terminals.delete(terminalId)
+  })
+
+  return terminalId
+}
+
 export function writeTerminal(terminalId: string, data: string): void {
   const terminal = terminals.get(terminalId)
   if (terminal) {

--- a/src/renderer/components/CommandSearch.tsx
+++ b/src/renderer/components/CommandSearch.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
-import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare } from 'lucide-react'
+import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare, TerminalSquare } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -28,6 +28,7 @@ interface Command {
 }
 
 const commands: Command[] = [
+  { id: 'add-terminal', label: 'Add Terminal', icon: TerminalSquare },
   { id: 'start-headless', label: 'Start: Headless Agent', icon: Container },
   { id: 'start-headless-discussion', label: 'Discuss: Headless Agent', icon: MessageSquare },
   { id: 'start-ralph-loop', label: 'Start: Ralph Loop', icon: RefreshCw },
@@ -47,6 +48,7 @@ interface CommandSearchProps {
   onStartHeadless?: (agentId: string, prompt: string, model: 'opus' | 'sonnet') => void
   onStartHeadlessDiscussion?: (agentId: string, initialPrompt: string) => void
   onStartRalphLoopDiscussion?: (agentId: string, initialPrompt: string) => void
+  onAddTerminal?: () => void
   onStartPlan?: () => void
   onStartRalphLoop?: (config: RalphLoopConfig) => void
   prefillRalphLoopConfig?: {
@@ -69,6 +71,7 @@ export function CommandSearch({
   onStartHeadless,
   onStartHeadlessDiscussion,
   onStartRalphLoopDiscussion,
+  onAddTerminal,
   onStartPlan,
   onStartRalphLoop,
   prefillRalphLoopConfig,
@@ -102,7 +105,8 @@ export function CommandSearch({
       !agent.isPlanAgent &&
       !agent.parentPlanId &&
       !agent.isHeadless &&
-      !agent.isStandaloneHeadless
+      !agent.isStandaloneHeadless &&
+      !agent.isTerminal
     )
   }, [agents])
 
@@ -326,7 +330,10 @@ export function CommandSearch({
       // Check if selecting a command or an agent
       if (idx < filteredCommands.length) {
         const command = filteredCommands[idx]
-        if (command.id === 'start-headless') {
+        if (command.id === 'add-terminal') {
+          onAddTerminal?.()
+          onOpenChange(false)
+        } else if (command.id === 'start-headless') {
           setPendingCommand('headless')
           setMode('agent-select')
           setQuery('')

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -35,6 +35,7 @@ export interface ElectronAPI {
   ) => Promise<void>
   closeTerminal: (terminalId: string) => Promise<void>
   stopWorkspace: (workspaceId: string) => Promise<void>
+  createTerminalAgent: (name: string, directory: string) => Promise<{ agentId: string; terminalId: string }>
 
   // State management
   getState: () => Promise<AppState>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,7 @@ export interface Agent {
   taskId?: string               // Associated task ID
   isHeadless?: boolean          // Running in headless Docker mode (no interactive terminal)
   isStandaloneHeadless?: boolean // Standalone headless agent (not part of a plan)
+  isTerminal?: boolean           // Terminal-only agent (plain shell, no Claude)
   order?: number                 // Display order in sidebar (lower = higher in list)
 }
 


### PR DESCRIPTION
## Summary

- Adds support for standalone terminal agents (plain shell, no Claude auto-start)
- New CMD-K command "Add Terminal" creates a terminal agent using the focused agent's directory
- Terminal agents occupy grid slots like regular agents but skip Claude session management
- Terminal agents excluded from headless/plan reference agent selection

## Changes

- `types.ts`: Added `isTerminal` flag to Agent interface
- `terminal.ts`: Added `createPlainTerminal()` function
- `main.ts`: Added `create-terminal-agent` IPC handler, terminal-aware `create-terminal` handler
- `preload.ts` + `electron.d.ts`: Exposed `createTerminalAgent` API
- `CommandSearch.tsx`: Added "Add Terminal" command to CMD-K palette
- `App.tsx`: Added `handleAddTerminal` handler and filtering

## Test plan

- [ ] Open CMD-K and verify "Add Terminal" appears as first command
- [ ] Select "Add Terminal" and verify a plain shell terminal opens in the grid
- [ ] Verify no Claude auto-starts in the terminal
- [ ] Verify terminal persists across tab switches
- [ ] Stop and relaunch terminal agent - verify it creates a plain terminal again
- [ ] Verify terminal agents don't appear in headless agent reference selection
- [ ] Verify terminal agents don't appear in plan reference agent dropdown
