### PR TITLE
Add terminal-only agents via CMD-K Add Terminal

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1343,6 +1343,15 @@ function App() {
     setActiveTabId(state.activeTabId)
   }
 
+  const handleAddTerminal = async (agent: Agent) => {
+    // Save the new terminal-only agent
+    await window.electronAPI.saveWorkspace(agent)
+    await loadAgents()
+
+    // Launch the terminal
+    await handleLaunchAgent(agent.id)
+  }
+
   const handleStopAgent = async (agentId: string) => {
     const activeTerminal = activeTerminals.find(
       (t) => t.workspaceId === agentId
@@ -3913,6 +3922,7 @@ function App() {
         onStartRalphLoopDiscussion={handleStartRalphLoopDiscussion}
         onStartPlan={() => setPlanCreatorOpen(true)}
         onStartRalphLoop={handleStartRalphLoop}
+        onAddTerminal={handleAddTerminal}
         prefillRalphLoopConfig={prefillRalphLoopConfig}
       />
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,7 @@ export interface Agent {
   taskId?: string               // Associated task ID
   isHeadless?: boolean          // Running in headless Docker mode (no interactive terminal)
   isStandaloneHeadless?: boolean // Standalone headless agent (not part of a plan)
+  isTerminalOnly?: boolean      // Plain shell terminal (no Claude agent)
   order?: number                 // Display order in sidebar (lower = higher in list)
 }
 


### PR DESCRIPTION
Adds terminal-only agents that spawn plain shell sessions without Claude, accessible via CMD-K command palette.