### PR TITLE
Add terminal-only tabs feature

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -425,6 +425,34 @@ function registerIpcHandlers() {
     }
   })
 
+  ipcMain.handle('create-terminal-only', async (_event) => {
+    devLog('[Main] create-terminal-only called')
+    try {
+      // Create a temporary agent for terminal-only mode
+      const agent: Workspace = {
+        id: randomUUID(),
+        name: 'Terminal',
+        directory: process.cwd(),
+        purpose: '',
+        theme: 'gray',
+        icon: 'kraftwerk',
+        isTerminalOnly: true,
+      }
+
+      // Save the workspace
+      saveWorkspace(agent)
+
+      // Use the queue for terminal creation with terminalOnly flag
+      const terminalId = await queueTerminalCreationWithSetup(agent.id, mainWindow, true)
+      devLog('[Main] create-terminal-only succeeded:', terminalId)
+
+      return agent
+    } catch (err) {
+      console.error('[Main] create-terminal-only FAILED:', err)
+      throw err
+    }
+  })
+
   ipcMain.handle('write-terminal', (_event, terminalId: string, data: string) => {
     writeTerminal(terminalId, data)
   })

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,6 +15,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Terminal management
   createTerminal: (workspaceId: string): Promise<string> =>
     ipcRenderer.invoke('create-terminal', workspaceId),
+  createTerminalOnly: (): Promise<Workspace> =>
+    ipcRenderer.invoke('create-terminal-only'),
   writeTerminal: (terminalId: string, data: string): Promise<void> =>
     ipcRenderer.invoke('write-terminal', terminalId, data),
   resizeTerminal: (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1738,6 +1738,19 @@ function App() {
     }
   }
 
+  // Create terminal-only handler
+  const handleCreateTerminalOnly = async () => {
+    try {
+      const agent = await window.electronAPI?.createTerminalOnly?.()
+      if (agent) {
+        // Reload agents to pick up the new terminal-only agent
+        await loadAgents()
+      }
+    } catch (error) {
+      console.error('Failed to create terminal-only agent:', error)
+    }
+  }
+
   // Start headless discussion handler
   const handleStartHeadlessDiscussion = async (agentId: string, initialPrompt: string) => {
     try {
@@ -3908,6 +3921,7 @@ function App() {
         tabs={tabs}
         activeTabId={activeTabId}
         onSelectAgent={handleCommandSearchSelect}
+        onCreateTerminalOnly={handleCreateTerminalOnly}
         onStartHeadless={handleStartStandaloneHeadless}
         onStartHeadlessDiscussion={handleStartHeadlessDiscussion}
         onStartRalphLoopDiscussion={handleStartRalphLoopDiscussion}

--- a/src/renderer/components/CommandSearch.tsx
+++ b/src/renderer/components/CommandSearch.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
-import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare } from 'lucide-react'
+import { Search, Container, ChevronLeft, FileText, RefreshCw, Save, MessageSquare, Terminal } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -28,6 +28,7 @@ interface Command {
 }
 
 const commands: Command[] = [
+  { id: 'add-terminal', label: 'Add Terminal', icon: Terminal },
   { id: 'start-headless', label: 'Start: Headless Agent', icon: Container },
   { id: 'start-headless-discussion', label: 'Discuss: Headless Agent', icon: MessageSquare },
   { id: 'start-ralph-loop', label: 'Start: Ralph Loop', icon: RefreshCw },
@@ -44,6 +45,7 @@ interface CommandSearchProps {
   tabs: AgentTab[]
   activeTabId: string | null
   onSelectAgent: (agentId: string) => void
+  onCreateTerminalOnly?: () => void
   onStartHeadless?: (agentId: string, prompt: string, model: 'opus' | 'sonnet') => void
   onStartHeadlessDiscussion?: (agentId: string, initialPrompt: string) => void
   onStartRalphLoopDiscussion?: (agentId: string, initialPrompt: string) => void
@@ -66,6 +68,7 @@ export function CommandSearch({
   waitingQueue,
   tabs,
   onSelectAgent,
+  onCreateTerminalOnly,
   onStartHeadless,
   onStartHeadlessDiscussion,
   onStartRalphLoopDiscussion,
@@ -95,14 +98,15 @@ export function CommandSearch({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
-  // Filter agents for selection (exclude orchestrators, plan agents, and headless agents)
+  // Filter agents for selection (exclude orchestrators, plan agents, headless agents, and terminal-only)
   const selectableAgents = useMemo(() => {
     return agents.filter(agent =>
       !agent.isOrchestrator &&
       !agent.isPlanAgent &&
       !agent.parentPlanId &&
       !agent.isHeadless &&
-      !agent.isStandaloneHeadless
+      !agent.isStandaloneHeadless &&
+      !agent.isTerminalOnly
     )
   }, [agents])
 
@@ -326,7 +330,10 @@ export function CommandSearch({
       // Check if selecting a command or an agent
       if (idx < filteredCommands.length) {
         const command = filteredCommands[idx]
-        if (command.id === 'start-headless') {
+        if (command.id === 'add-terminal') {
+          onCreateTerminalOnly?.()
+          onOpenChange(false)
+        } else if (command.id === 'start-headless') {
           setPendingCommand('headless')
           setMode('agent-select')
           setQuery('')

--- a/src/renderer/components/WorkspaceCard.tsx
+++ b/src/renderer/components/WorkspaceCard.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2, Play, Square, MoreVertical, Container, GripVertical, Copy } from 'lucide-react'
+import { Pencil, Trash2, Play, Square, MoreVertical, Container, GripVertical, Copy, Terminal } from 'lucide-react'
 import { Button } from '@/renderer/components/ui/button'
 import {
   DropdownMenu,
@@ -120,6 +120,12 @@ export function AgentCard({
           <AgentIcon icon={agent.icon} className="w-4 h-4" />
         </div>
         <h3 className="font-medium truncate flex-1" data-testid={`agent-card-name-${agent.id}`}>{agent.name}</h3>
+        {agent.isTerminalOnly && (
+          <span className="text-xs bg-gray-600 text-white px-1.5 py-0.5 rounded flex-shrink-0 flex items-center gap-1">
+            <Terminal className="w-3 h-3" />
+            Terminal
+          </span>
+        )}
         {agent.isHeadless && (
           <span className="text-xs bg-blue-600 text-white px-1.5 py-0.5 rounded flex-shrink-0 flex items-center gap-1">
             <Container className="w-3 h-3" />

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -27,6 +27,7 @@ export interface ElectronAPI {
 
   // Terminal management
   createTerminal: (workspaceId: string) => Promise<string>
+  createTerminalOnly: () => Promise<Workspace>
   writeTerminal: (terminalId: string, data: string) => Promise<void>
   resizeTerminal: (
     terminalId: string,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,7 @@ export interface Agent {
   taskId?: string               // Associated task ID
   isHeadless?: boolean          // Running in headless Docker mode (no interactive terminal)
   isStandaloneHeadless?: boolean // Standalone headless agent (not part of a plan)
+  isTerminalOnly?: boolean      // Terminal-only slot (no Claude session, just shell)
   order?: number                 // Display order in sidebar (lower = higher in list)
 }
 


### PR DESCRIPTION
Adds support for terminal-only tabs that work like agents but don't run Claude. Use CMD-K and select Add Terminal to create a plain shell terminal that occupies a grid slot like regular agents.