### PR TITLE
feat: Save custom personas in settings

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -146,6 +146,10 @@ import {
   checkGitHubTokenScopes,
   updatePlayboxSettings,
   loadSettings,
+  getSavedPersonas,
+  addSavedPersona,
+  updateSavedPersona,
+  deleteSavedPersona,
   getRalphLoopPresets,
   addRalphLoopPreset,
   updateRalphLoopPreset,
@@ -1125,6 +1129,23 @@ function registerIpcHandlers() {
   ipcMain.handle('get-playbox-settings', async () => {
     const appSettings = await loadSettings()
     return appSettings.playbox
+  })
+
+  // Saved persona management
+  ipcMain.handle('get-saved-personas', async () => {
+    return getSavedPersonas()
+  })
+
+  ipcMain.handle('add-saved-persona', async (_event, persona: { name: string; prompt: string }) => {
+    return addSavedPersona(persona)
+  })
+
+  ipcMain.handle('update-saved-persona', async (_event, id: string, updates: { name?: string; prompt?: string }) => {
+    return updateSavedPersona(id, updates)
+  })
+
+  ipcMain.handle('delete-saved-persona', async (_event, id: string) => {
+    return deleteSavedPersona(id)
   })
 
   // Ralph Loop preset management

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -451,6 +451,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getPlayboxSettings: (): Promise<{ personaMode: 'none' | 'bismarck' | 'otto' | 'custom'; customPersonaPrompt: string | null }> =>
     ipcRenderer.invoke('get-playbox-settings'),
 
+  // Saved persona management
+  getSavedPersonas: (): Promise<Array<{ id: string; name: string; prompt: string }>> =>
+    ipcRenderer.invoke('get-saved-personas'),
+  addSavedPersona: (persona: { name: string; prompt: string }): Promise<{ id: string; name: string; prompt: string }> =>
+    ipcRenderer.invoke('add-saved-persona', persona),
+  updateSavedPersona: (id: string, updates: { name?: string; prompt?: string }): Promise<{ id: string; name: string; prompt: string } | undefined> =>
+    ipcRenderer.invoke('update-saved-persona', id, updates),
+  deleteSavedPersona: (id: string): Promise<boolean> =>
+    ipcRenderer.invoke('delete-saved-persona', id),
+
   // Ralph Loop preset management
   getRalphLoopPresets: (): Promise<Array<{ id: string; label: string; description: string; prompt: string; completionPhrase: string; maxIterations: number; model: 'opus' | 'sonnet' }>> =>
     ipcRenderer.invoke('get-ralph-loop-presets'),

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -126,6 +126,12 @@ export interface ElectronAPI {
   getAllRalphLoops: () => Promise<RalphLoopState[]>
   cleanupRalphLoop: (loopId: string) => Promise<void>
 
+  // Saved personas
+  getSavedPersonas: () => Promise<Array<{ id: string; name: string; prompt: string }>>
+  addSavedPersona: (persona: { name: string; prompt: string }) => Promise<{ id: string; name: string; prompt: string }>
+  updateSavedPersona: (id: string, updates: { name?: string; prompt?: string }) => Promise<{ id: string; name: string; prompt: string } | undefined>
+  deleteSavedPersona: (id: string) => Promise<boolean>
+
   // Ralph Loop presets
   getRalphLoopPresets: () => Promise<Array<{ id: string; label: string; description: string; prompt: string; completionPhrase: string; maxIterations: number; model: 'opus' | 'sonnet' }>>
   addRalphLoopPreset: (preset: { label: string; description: string; prompt: string; completionPhrase: string; maxIterations: number; model: 'opus' | 'sonnet' }) => Promise<{ id: string; label: string; description: string; prompt: string; completionPhrase: string; maxIterations: number; model: 'opus' | 'sonnet' }>


### PR DESCRIPTION
Add ability to save, load, edit, and delete custom personas in Playbox settings. Users can create named persona presets from their custom prompts and quickly switch between them.