### PR TITLE
fix: Add re-check dependencies button to plan-mode wizard step

### DIFF
--- a/src/renderer/components/SetupWizard.tsx
+++ b/src/renderer/components/SetupWizard.tsx
@@ -1509,6 +1509,18 @@ export function SetupWizard({ onComplete, onSkip }: SetupWizardProps) {
                 </div>
               )}
 
+              {/* Re-check button */}
+              {planModeEnabled && !isCheckingDeps && dependencies && (
+                <Button
+                  onClick={checkDependencies}
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                >
+                  Re-check Dependencies
+                </Button>
+              )}
+
               {/* Error Message */}
               {error && (
                 <div className="text-destructive text-sm bg-destructive/10 border border-destructive/20 rounded-md p-3">


### PR DESCRIPTION
The optional dependencies step in the setup wizard (plan-mode step) had no way to re-check dependencies after manually installing them. Step 1 (deps) already had a Re-check button but step 5 (plan-mode) did not. Adds the same button, shown when headless agents are enabled. Fixes bismarck-8z6