### PR TITLE
bismarck-0ubu: Follow-up modal should not block UI while starting

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1612,7 +1612,10 @@ function App() {
     const headlessId = followUpInfo?.taskId
     if (!headlessId) return
 
+    // Close modal immediately — loading state is shown on the agent card via startingFollowUpIds
     setStartingFollowUpIds(prev => new Set(prev).add(headlessId))
+    setFollowUpInfo(null)
+
     try {
       const result = await window.electronAPI?.standaloneHeadlessStartFollowup?.(headlessId, prompt, model)
       if (result) {
@@ -1627,8 +1630,6 @@ function App() {
         // Refresh tabs
         const state = await window.electronAPI.getState()
         setTabs(state.tabs || [])
-        // Close the modal
-        setFollowUpInfo(null)
       }
     } finally {
       setStartingFollowUpIds(prev => {


### PR DESCRIPTION
Close the follow-up modal immediately when user clicks Start Follow-up, instead of blocking with a spinner while the IPC call completes. Loading state is already visible on the agent card via startingFollowUpIds.