### PR TITLE
bismarck-9pkk: Preserve original workspace on follow-up

### DIFF
--- a/src/main/headless/standalone.ts
+++ b/src/main/headless/standalone.ts
@@ -770,17 +770,11 @@ export async function startFollowUpAgent(
   // Save the workspace
   saveWorkspace(newAgent)
 
-  // Clean up old workspace so its grid slot is freed
-  let preferredTabId: string | undefined
-  if (existingWorkspace) {
-    const oldTab = getTabForWorkspace(existingWorkspace.id)
-    preferredTabId = oldTab?.id
-    removeActiveWorkspace(existingWorkspace.id)
-    removeWorkspaceFromTab(existingWorkspace.id)
-    deleteWorkspace(existingWorkspace.id)
-  }
-
-  // Place new agent in the same tab/slot as old workspace (or next available)
+  // Keep original workspace visible so users can reference its terminal output.
+  // Place follow-up in the same tab if there's room, otherwise next available slot.
+  const preferredTabId = existingWorkspace
+    ? getTabForWorkspace(existingWorkspace.id)?.id
+    : undefined
   const tab = getOrCreateTabForWorkspaceWithPreference(workspaceId, preferredTabId)
   addWorkspaceToTab(workspaceId, tab.id)
   setActiveTab(tab.id)
@@ -802,8 +796,7 @@ export async function startFollowUpAgent(
   }
   standaloneHeadlessAgentInfo.set(newHeadlessId, agentInfo)
 
-  // Remove old agent info (worktree is now owned by new agent)
-  standaloneHeadlessAgentInfo.delete(headlessId)
+  // Keep old agent info so its terminal output remains accessible
 
   // Emit initial state
   emitHeadlessAgentUpdate(agentInfo)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1616,13 +1616,7 @@ function App() {
     try {
       const result = await window.electronAPI?.standaloneHeadlessStartFollowup?.(headlessId, prompt, model)
       if (result) {
-        // Remove old agent info from map
-        setHeadlessAgents((prev) => {
-          const newMap = new Map(prev)
-          newMap.delete(headlessId)
-          return newMap
-        })
-        // Reload agents to pick up the new workspace
+        // Reload agents to pick up both old and new workspaces
         await loadAgents()
         // Refresh tabs
         const state = await window.electronAPI.getState()


### PR DESCRIPTION
Stop deleting original workspace when starting a follow-up agent. Keep original terminal output accessible by preserving the workspace in its tab slot. Follow-up agent gets its own new workspace slot (same tab preferred, next available otherwise). Preserve old HeadlessAgentInfo in memory so renderer can still display it.