### PR TITLE
bismarck-i39w: Bind CDP test server to 127.0.0.1

### DIFF
--- a/scripts/test/cdp-server.js
+++ b/scripts/test/cdp-server.js
@@ -485,8 +485,8 @@ async function handleRequest(req, res) {
 // Create and start server
 const server = http.createServer(handleRequest);
 
-server.listen(PORT, () => {
-  console.log(`CDP Server running on http://localhost:${PORT}`);
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`CDP Server running on http://127.0.0.1:${PORT}`);
   console.log('');
   console.log('Endpoints:');
   console.log('  GET  /health                      - Check server status');


### PR DESCRIPTION
Binds the CDP test server to 127.0.0.1 instead of 0.0.0.0 to prevent network-accessible access to the /eval endpoint which executes arbitrary JS in the Electron renderer.