### PR TITLE
feat: Add BuildBuddy API key storage and MCP server in Docker

### DIFF
--- a/src/main/buildbuddy-mcp-detect.ts
+++ b/src/main/buildbuddy-mcp-detect.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+
+export interface McpDetectionResult {
+  path: string | null
+  source: string
+  valid: boolean
+}
+
+/**
+ * Detect the BuildBuddy MCP server installation path.
+ *
+ * Checks these sources in order:
+ * 1. Global mcpServers.buildbuddy in ~/.claude.json
+ * 2. Per-project mcpServers.buildbuddy in ~/.claude.json projects
+ * 3. Well-known paths: ~/.local/lib/buildbuddy-mcp, /usr/local/lib/buildbuddy-mcp
+ */
+export async function detectBuildBuddyMcpPath(): Promise<McpDetectionResult> {
+  const claudeJsonPath = path.join(os.homedir(), '.claude.json')
+
+  try {
+    const raw = await fs.readFile(claudeJsonPath, 'utf-8')
+    const claudeConfig = JSON.parse(raw)
+
+    // 1. Check global mcpServers.buildbuddy
+    const globalMcp = claudeConfig?.mcpServers?.buildbuddy
+    if (globalMcp?.args?.[0]) {
+      const candidate = extractMcpDir(globalMcp.args[0])
+      if (candidate) {
+        const valid = await validateMcpPath(candidate)
+        return { path: candidate, source: '~/.claude.json (global)', valid }
+      }
+    }
+
+    // 2. Check per-project mcpServers.buildbuddy
+    const projects = claudeConfig?.projects
+    if (projects && typeof projects === 'object') {
+      for (const [projectPath, projectConfig] of Object.entries(projects)) {
+        const config = projectConfig as Record<string, unknown>
+        const mcpServers = config?.mcpServers as Record<string, { args?: string[] }> | undefined
+        const bbMcp = mcpServers?.buildbuddy
+        if (bbMcp?.args?.[0]) {
+          const candidate = extractMcpDir(bbMcp.args[0])
+          if (candidate) {
+            const valid = await validateMcpPath(candidate)
+            const projectName = path.basename(projectPath)
+            return { path: candidate, source: `~/.claude.json (${projectName} project)`, valid }
+          }
+        }
+      }
+    }
+  } catch {
+    // ~/.claude.json missing or unparseable — fall through to well-known paths
+  }
+
+  // 3. Well-known paths
+  const wellKnownPaths = [
+    path.join(os.homedir(), '.local', 'lib', 'buildbuddy-mcp'),
+    '/usr/local/lib/buildbuddy-mcp',
+  ]
+
+  for (const candidate of wellKnownPaths) {
+    const valid = await validateMcpPath(candidate)
+    if (valid) {
+      return { path: candidate, source: 'well-known path', valid: true }
+    }
+  }
+
+  return { path: null, source: 'not found', valid: false }
+}
+
+/**
+ * Extract the MCP server directory from an args[0] path like
+ * "/path/to/buildbuddy-mcp/dist/index.js" → "/path/to/buildbuddy-mcp"
+ */
+function extractMcpDir(argsPath: string): string | null {
+  // Expected: .../dist/index.js — go up two levels
+  const dir = path.dirname(path.dirname(argsPath))
+  if (!dir || dir === '.' || dir === '/') return null
+  return dir
+}
+
+/**
+ * Validate that <dir>/dist/index.js exists.
+ */
+async function validateMcpPath(dir: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(dir, 'dist', 'index.js'))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -595,6 +595,56 @@ export function clearConfiguredGitHubToken(): void {
   }
 }
 
+// BuildBuddy API key storage
+const BUILDBUDDY_TOKEN_FILE = 'buildbuddy-token.json'
+
+interface BuildBuddyTokenData {
+  token: string
+  createdAt: string
+}
+
+function getBuildBuddyTokenPath(): string {
+  return path.join(getConfigDir(), BUILDBUDDY_TOKEN_FILE)
+}
+
+/**
+ * Get the configured BuildBuddy API key from file storage
+ */
+export function getConfiguredBuildBuddyApiKey(): string | null {
+  const tokenPath = getBuildBuddyTokenPath()
+  try {
+    const content = fs.readFileSync(tokenPath, 'utf-8')
+    const data = JSON.parse(content) as BuildBuddyTokenData
+    return data.token || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Store the BuildBuddy API key
+ */
+export function setConfiguredBuildBuddyApiKey(token: string): void {
+  const tokenPath = getBuildBuddyTokenPath()
+  const data: BuildBuddyTokenData = {
+    token,
+    createdAt: new Date().toISOString(),
+  }
+  writeConfigAtomic(tokenPath, data, 0o600)
+}
+
+/**
+ * Clear the stored BuildBuddy API key
+ */
+export function clearConfiguredBuildBuddyApiKey(): void {
+  const tokenPath = getBuildBuddyTokenPath()
+  try {
+    fs.unlinkSync(tokenPath)
+  } catch {
+    // File doesn't exist, that's fine
+  }
+}
+
 // Plan activities persistence (per-plan)
 export function loadPlanActivities(planId: string): PlanActivity[] {
   const activitiesPath = getPlanActivitiesPath(planId)

--- a/src/main/docker-sandbox.ts
+++ b/src/main/docker-sandbox.ts
@@ -458,7 +458,7 @@ async function buildDockerArgs(config: ContainerConfig): Promise<string[]> {
 
         const tmpConfigPath = path.join(os.tmpdir(), `bismarck-claude-config-${Date.now()}.json`)
         await fs.writeFile(tmpConfigPath, JSON.stringify(claudeJson, null, 2))
-        args.push('-v', `${tmpConfigPath}:/home/agent/.claude.json:ro`)
+        args.push('-v', `${tmpConfigPath}:/home/agent/.claude.json`)
       } catch {
         logger.error('docker', 'BuildBuddy MCP dist/index.js not found at configured path', undefined, {
           path: mcpHostPath,

--- a/src/main/docker-sandbox.ts
+++ b/src/main/docker-sandbox.ts
@@ -400,42 +400,79 @@ async function buildDockerArgs(config: ContainerConfig): Promise<string[]> {
   }
 
   // Mount BuildBuddy MCP server if configured
-  if (settings.docker.buildbuddyMcp?.enabled && settings.docker.buildbuddyMcp?.hostPath) {
-    const mcpHostPath = settings.docker.buildbuddyMcp.hostPath
-    try {
-      await fs.access(mcpHostPath)
-      devLog('[DockerSandbox] Mounting BuildBuddy MCP server from:', mcpHostPath)
-      args.push('-v', `${mcpHostPath}:/mcp/buildbuddy:ro`)
-      args.push('-e', 'BAZEL_BINDIR=/workspace/bazel-bin')
+  if (settings.docker.buildbuddyMcp?.enabled) {
+    let mcpHostPath = settings.docker.buildbuddyMcp.hostPath
 
-      // Generate Claude Code MCP config and mount it
-      // Claude Code stores MCP servers per-project under projects["/workspace"]
-      const claudeConfig = JSON.stringify({
-        hasCompletedOnboarding: true,
-        projects: {
-          '/workspace': {
-            mcpServers: {
-              buildbuddy: {
-                type: 'stdio',
-                command: 'node',
-                args: ['/mcp/buildbuddy/index.js'],
-                env: {
-                  BAZEL_BINDIR: '/workspace/bazel-bin',
-                },
-              },
-            },
-            hasTrustDialogAccepted: true,
-            hasCompletedProjectOnboarding: true,
+    // Auto-detect if hostPath is not explicitly configured
+    if (!mcpHostPath) {
+      const { detectBuildBuddyMcpPath } = await import('./buildbuddy-mcp-detect')
+      const detection = await detectBuildBuddyMcpPath()
+      if (detection.path) {
+        mcpHostPath = detection.path
+        devLog('[DockerSandbox] Auto-detected BuildBuddy MCP path:', mcpHostPath, `(from ${detection.source})`)
+      }
+    }
+
+    if (mcpHostPath) {
+      try {
+        await fs.access(path.join(mcpHostPath, 'dist', 'index.js'))
+        devLog('[DockerSandbox] Mounting BuildBuddy MCP server from:', mcpHostPath)
+        args.push('-v', `${mcpHostPath}:/mcp/buildbuddy:ro`)
+        args.push('-e', 'BAZEL_BINDIR=/workspace/bazel-bin')
+
+        // Merge MCP config into host's ~/.claude.json so we don't clobber
+        // auth state, onboarding flags, or other fields Claude Code needs.
+        const hostClaudeJsonPath = path.join(os.homedir(), '.claude.json')
+        let claudeJson: Record<string, unknown> = {}
+        try {
+          const raw = await fs.readFile(hostClaudeJsonPath, 'utf-8')
+          claudeJson = JSON.parse(raw)
+        } catch { /* file missing or invalid — start fresh */ }
+
+        claudeJson.hasCompletedOnboarding = true
+
+        // Build the MCP server entry pointing to the container path
+        const bbMcpEntry = {
+          type: 'stdio',
+          command: 'node',
+          args: ['/mcp/buildbuddy/dist/index.js'],
+          env: {
+            BAZEL_BINDIR: '/workspace/bazel-bin',
           },
-        },
-      }, null, 2)
-      const tmpConfigPath = path.join(os.tmpdir(), `bismarck-claude-config-${Date.now()}.json`)
-      await fs.writeFile(tmpConfigPath, claudeConfig)
-      args.push('-v', `${tmpConfigPath}:/home/agent/.claude.json:ro`)
-    } catch {
-      // MCP path doesn't exist, skip mounting
-      logger.warn('docker', 'BuildBuddy MCP hostPath not found, skipping', undefined, {
-        path: mcpHostPath,
+        }
+
+        // Set top-level mcpServers (overrides host paths with container paths)
+        const topLevelMcp = (claudeJson.mcpServers || {}) as Record<string, unknown>
+        topLevelMcp.buildbuddy = bbMcpEntry
+        claudeJson.mcpServers = topLevelMcp
+
+        // Also inject under projects["/workspace"] for per-project discovery
+        const projects = (claudeJson.projects || {}) as Record<string, Record<string, unknown>>
+        const workspaceProject = projects['/workspace'] || {}
+        const existingMcp = (workspaceProject.mcpServers || {}) as Record<string, unknown>
+        workspaceProject.mcpServers = { ...existingMcp, buildbuddy: bbMcpEntry }
+        workspaceProject.hasTrustDialogAccepted = true
+        workspaceProject.hasCompletedProjectOnboarding = true
+        projects['/workspace'] = workspaceProject
+        claudeJson.projects = projects
+
+        const tmpConfigPath = path.join(os.tmpdir(), `bismarck-claude-config-${Date.now()}.json`)
+        await fs.writeFile(tmpConfigPath, JSON.stringify(claudeJson, null, 2))
+        args.push('-v', `${tmpConfigPath}:/home/agent/.claude.json:ro`)
+      } catch {
+        logger.error('docker', 'BuildBuddy MCP dist/index.js not found at configured path', undefined, {
+          path: mcpHostPath,
+        })
+        containerEvents.emit('config-warning', {
+          type: 'buildbuddy-mcp',
+          message: `BuildBuddy MCP server not found at ${mcpHostPath}/dist/index.js — may need rebuild`,
+        })
+      }
+    } else {
+      logger.error('docker', 'BuildBuddy MCP enabled but path could not be detected. Install with: claude mcp add buildbuddy -s user')
+      containerEvents.emit('config-warning', {
+        type: 'buildbuddy-mcp',
+        message: 'BuildBuddy MCP server not found. Install with: claude mcp add buildbuddy -s user',
       })
     }
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -182,6 +182,8 @@ import {
   updateDockerPnpmStoreSettings,
   updateDockerNetworkIsolationSettings,
   updateSettings,
+  hasBuildBuddyApiKey,
+  setBuildBuddyApiKey,
 } from './settings-manager'
 import { clearDebugSettingsCache, getGlobalLogPath } from './logger'
 import { writeCrashLog } from './crash-logger'
@@ -1300,6 +1302,21 @@ function registerIpcHandlers() {
 
   ipcMain.handle('check-github-token-scopes', async () => {
     return checkGitHubTokenScopes()
+  })
+
+  // BuildBuddy API key management
+  ipcMain.handle('has-buildbuddy-api-key', async () => {
+    return hasBuildBuddyApiKey()
+  })
+
+  ipcMain.handle('set-buildbuddy-api-key', async (_event, key: string) => {
+    await setBuildBuddyApiKey(key)
+    return true
+  })
+
+  ipcMain.handle('clear-buildbuddy-api-key', async () => {
+    await setBuildBuddyApiKey(null)
+    return true
   })
 
   // Settings management

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1459,6 +1459,11 @@ function registerIpcHandlers() {
     return detectPnpmStorePath()
   })
 
+  ipcMain.handle('detect-buildbuddy-mcp-path', async () => {
+    const { detectBuildBuddyMcpPath } = await import('./buildbuddy-mcp-detect')
+    return detectBuildBuddyMcpPath()
+  })
+
   ipcMain.handle('set-raw-settings', async (_event, settings: unknown) => {
     return saveSettings(settings as AppSettings)
   })

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -438,6 +438,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkGitHubTokenScopes: (): Promise<{ valid: boolean; scopes: string[]; missingScopes: string[]; ssoConfigured: boolean | null; error?: string }> =>
     ipcRenderer.invoke('check-github-token-scopes'),
 
+  // BuildBuddy API key management
+  hasBuildBuddyApiKey: (): Promise<boolean> =>
+    ipcRenderer.invoke('has-buildbuddy-api-key'),
+  setBuildBuddyApiKey: (key: string): Promise<boolean> =>
+    ipcRenderer.invoke('set-buildbuddy-api-key', key),
+  clearBuildBuddyApiKey: (): Promise<boolean> =>
+    ipcRenderer.invoke('clear-buildbuddy-api-key'),
+
   // Settings management
   getSettings: () => ipcRenderer.invoke('get-settings'),
   updateSettings: (updates: Record<string, unknown>): Promise<void> =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -495,6 +495,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('reset-docker-network-isolation-hosts'),
   detectPnpmStorePath: () =>
     ipcRenderer.invoke('detect-pnpm-store-path'),
+  detectBuildBuddyMcpPath: (): Promise<{ path: string | null; source: string; valid: boolean }> =>
+    ipcRenderer.invoke('detect-buildbuddy-mcp-path'),
   setRawSettings: (settings: unknown) =>
     ipcRenderer.invoke('set-raw-settings', settings),
 

--- a/src/main/tool-proxy.ts
+++ b/src/main/tool-proxy.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from 'events'
 import { logger } from './logger'
 import { spawnWithPath, getEnvWithPath } from './exec-utils'
 import { getConfigDir } from './config'
-import { getGitHubToken, loadSettings } from './settings-manager'
+import { getGitHubToken, getBuildBuddyApiKey, loadSettings } from './settings-manager'
 import { getGitUserConfig } from './git-utils'
 
 export interface ToolProxyConfig {
@@ -639,11 +639,13 @@ async function handleBbRequest(
     // Forward BUILDBUDDY_API_KEY so bb works outside git repos (e.g., worktrees)
     // Forward GITHUB_TOKEN so bb remote can authenticate to private repos for Go modules
     const env: Record<string, string> = {}
-    if (process.env.BUILDBUDDY_API_KEY) {
-      env.BUILDBUDDY_API_KEY = process.env.BUILDBUDDY_API_KEY
+    const buildBuddyKey = await getBuildBuddyApiKey()
+    if (buildBuddyKey) {
+      env.BUILDBUDDY_API_KEY = buildBuddyKey
     }
-    if (process.env.GITHUB_TOKEN) {
-      env.GITHUB_TOKEN = process.env.GITHUB_TOKEN
+    const githubToken = await getGitHubToken()
+    if (githubToken) {
+      env.GITHUB_TOKEN = githubToken
     }
 
     const result = await executeCommand('bb', args, body.stdin, {

--- a/src/renderer/components/settings/sections/AuthenticationSettings.tsx
+++ b/src/renderer/components/settings/sections/AuthenticationSettings.tsx
@@ -559,23 +559,19 @@ export function AuthenticationSettings() {
           <div className="space-y-0.5">
             <Label className="text-base font-medium">BuildBuddy API Key</Label>
             <p className="text-sm text-muted-foreground">
-              Used for <code className="bg-muted px-1 rounded text-xs">bb</code> CLI and BuildBuddy MCP server authentication
+              Used for <code className="bg-muted px-1 rounded text-xs">bb</code> CLI authentication in headless agents
             </p>
           </div>
           <div className="flex items-center gap-2">
             {hasBuildBuddyKey ? (
               <>
                 <Check className="h-4 w-4 text-green-500" />
-                <span className="text-sm text-green-600 dark:text-green-400 font-medium">
-                  Configured
-                </span>
+                <span className="text-sm text-green-600 dark:text-green-400 font-medium">Configured</span>
               </>
             ) : (
               <>
                 <X className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm text-muted-foreground">
-                  Not configured
-                </span>
+                <span className="text-sm text-muted-foreground">Not configured</span>
               </>
             )}
           </div>
@@ -583,10 +579,10 @@ export function AuthenticationSettings() {
 
         {/* Manual entry */}
         <div className="space-y-2">
-          <Label htmlFor="buildbuddy-key">API Key</Label>
+          <Label htmlFor="buildbuddy-api-key">API Key</Label>
           <div className="flex gap-2">
             <Input
-              id="buildbuddy-key"
+              id="buildbuddy-api-key"
               type="password"
               placeholder={hasBuildBuddyKey ? '••••••••' : 'Enter BuildBuddy API key'}
               value={newBuildBuddyKey}
@@ -620,7 +616,10 @@ export function AuthenticationSettings() {
           <div className="flex gap-2">
             <Info className="h-4 w-4 text-blue-500 flex-shrink-0 mt-0.5" />
             <p className="text-xs text-blue-600 dark:text-blue-400">
-              <strong>What is this?</strong> The BuildBuddy API key is used to authenticate the <code className="bg-muted px-1 rounded">bb</code> CLI tool and the BuildBuddy MCP server in Docker containers. It is passed via the <code className="bg-muted px-1 rounded">BUILDBUDDY_API_KEY</code> environment variable. If the key is set in your shell environment, it will take precedence over the stored value.
+              <strong>What is this?</strong> The BuildBuddy API key authenticates <code className="bg-muted px-1 rounded">bb</code> CLI commands
+              (remote builds, test execution) in headless agents and Docker containers. The key is passed via
+              the <code className="bg-muted px-1 rounded">BUILDBUDDY_API_KEY</code> environment variable. If set in your shell environment,
+              it will be used automatically.
             </p>
           </div>
         </div>

--- a/src/renderer/components/settings/sections/AuthenticationSettings.tsx
+++ b/src/renderer/components/settings/sections/AuthenticationSettings.tsx
@@ -20,6 +20,11 @@ export function AuthenticationSettings() {
   const [tokenCreatedAt, setTokenCreatedAt] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // BuildBuddy API key state
+  const [hasBuildBuddyKey, setHasBuildBuddyKey] = useState(false)
+  const [newBuildBuddyKey, setNewBuildBuddyKey] = useState('')
+  const [savingBuildBuddyKey, setSavingBuildBuddyKey] = useState(false)
+
   // GitHub token state
   const [hasGitHubToken, setHasGitHubToken] = useState(false)
   const [newGitHubToken, setNewGitHubToken] = useState('')
@@ -59,12 +64,14 @@ export function AuthenticationSettings() {
 
   const checkTokenStatus = async () => {
     try {
-      const [oauthConfigured, gitHubConfigured] = await Promise.all([
+      const [oauthConfigured, gitHubConfigured, buildBuddyConfigured] = await Promise.all([
         window.electronAPI.hasOAuthToken(),
         window.electronAPI.hasGitHubToken(),
+        window.electronAPI.hasBuildBuddyApiKey(),
       ])
       setHasToken(oauthConfigured)
       setHasGitHubToken(gitHubConfigured)
+      setHasBuildBuddyKey(buildBuddyConfigured)
       // Note: We don't have token creation timestamp - the API returns just the token string
       setTokenCreatedAt(null)
     } catch (err) {
@@ -152,6 +159,35 @@ export function AuthenticationSettings() {
       setGitHubTokenDetectResult({ success: false, source: null })
     } finally {
       setDetectingGitHubToken(false)
+    }
+  }
+
+  // BuildBuddy API key handlers
+  const handleSaveBuildBuddyKey = async () => {
+    if (!newBuildBuddyKey.trim()) return
+
+    setSavingBuildBuddyKey(true)
+    try {
+      await window.electronAPI.setBuildBuddyApiKey(newBuildBuddyKey.trim())
+      setNewBuildBuddyKey('')
+      setHasBuildBuddyKey(true)
+      setShowSaved(true)
+      setTimeout(() => setShowSaved(false), 2000)
+    } catch (error) {
+      console.error('Failed to save BuildBuddy API key:', error)
+    } finally {
+      setSavingBuildBuddyKey(false)
+    }
+  }
+
+  const handleClearBuildBuddyKey = async () => {
+    try {
+      await window.electronAPI.clearBuildBuddyApiKey()
+      setHasBuildBuddyKey(false)
+      setShowSaved(true)
+      setTimeout(() => setShowSaved(false), 2000)
+    } catch (error) {
+      console.error('Failed to clear BuildBuddy API key:', error)
     }
   }
 
@@ -513,6 +549,79 @@ export function AuthenticationSettings() {
                 <strong>When to use:</strong> If you're getting SAML SSO errors when creating PRs for organization repositories, you need to configure a token here. The token is passed to <code className="bg-muted px-1 rounded">gh</code> commands via the <code className="bg-muted px-1 rounded">GITHUB_TOKEN</code> environment variable.
               </p>
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* BuildBuddy API Key Section */}
+      <div className="border-t pt-6 space-y-4">
+        <div className="flex items-center justify-between py-2">
+          <div className="space-y-0.5">
+            <Label className="text-base font-medium">BuildBuddy API Key</Label>
+            <p className="text-sm text-muted-foreground">
+              Used for <code className="bg-muted px-1 rounded text-xs">bb</code> CLI and BuildBuddy MCP server authentication
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {hasBuildBuddyKey ? (
+              <>
+                <Check className="h-4 w-4 text-green-500" />
+                <span className="text-sm text-green-600 dark:text-green-400 font-medium">
+                  Configured
+                </span>
+              </>
+            ) : (
+              <>
+                <X className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  Not configured
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Manual entry */}
+        <div className="space-y-2">
+          <Label htmlFor="buildbuddy-key">API Key</Label>
+          <div className="flex gap-2">
+            <Input
+              id="buildbuddy-key"
+              type="password"
+              placeholder={hasBuildBuddyKey ? '••••••••' : 'Enter BuildBuddy API key'}
+              value={newBuildBuddyKey}
+              onChange={(e) => setNewBuildBuddyKey(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleSaveBuildBuddyKey()
+                }
+              }}
+            />
+            <Button
+              onClick={handleSaveBuildBuddyKey}
+              disabled={!newBuildBuddyKey.trim() || savingBuildBuddyKey}
+            >
+              <Save className="h-4 w-4 mr-2" />
+              {savingBuildBuddyKey ? 'Saving...' : 'Save'}
+            </Button>
+            {hasBuildBuddyKey && (
+              <Button
+                onClick={handleClearBuildBuddyKey}
+                variant="outline"
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Info box */}
+        <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-md">
+          <div className="flex gap-2">
+            <Info className="h-4 w-4 text-blue-500 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-blue-600 dark:text-blue-400">
+              <strong>What is this?</strong> The BuildBuddy API key is used to authenticate the <code className="bg-muted px-1 rounded">bb</code> CLI tool and the BuildBuddy MCP server in Docker containers. It is passed via the <code className="bg-muted px-1 rounded">BUILDBUDDY_API_KEY</code> environment variable. If the key is set in your shell environment, it will take precedence over the stored value.
+            </p>
           </div>
         </div>
       </div>

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -251,6 +251,7 @@ export interface ElectronAPI {
   updateDockerNetworkIsolationSettings: (settings: { enabled?: boolean; allowedHosts?: string[] }) => Promise<void>
   resetDockerNetworkIsolationHosts: () => Promise<string[]>
   detectPnpmStorePath: () => Promise<string | null>
+  detectBuildBuddyMcpPath: () => Promise<{ path: string | null; source: string; valid: boolean }>
   setRawSettings: (settings: unknown) => Promise<AppSettings>
 
   // Prompt management

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -222,6 +222,11 @@ export interface ElectronAPI {
   clearGitHubToken: () => Promise<boolean>
   checkGitHubTokenScopes: () => Promise<{ valid: boolean; scopes: string[]; missingScopes: string[]; ssoConfigured: boolean | null; error?: string }>
 
+  // BuildBuddy API key management
+  hasBuildBuddyApiKey: () => Promise<boolean>
+  setBuildBuddyApiKey: (key: string) => Promise<boolean>
+  clearBuildBuddyApiKey: () => Promise<boolean>
+
   // Settings management
   getSettings: () => Promise<AppSettings>
   updateSettings: (updates: Partial<AppSettings>) => Promise<AppSettings>


### PR DESCRIPTION
## Summary

- Adds persistent BuildBuddy API key storage following the existing GitHub token pattern (file-based storage with env var precedence)
- Passes stored API key to `bb` CLI via tool-proxy and to Docker containers as `BUILDBUDDY_API_KEY` env var
- Adds configurable BuildBuddy MCP server mounting for Docker containers (mounts server directory read-only, generates `.claude.json` config)
- Adds Authentication settings UI section for managing the BuildBuddy API key
- Adds Docker settings UI section for enabling/configuring the MCP server mount

## Files Changed

- `src/main/config.ts` — BuildBuddy token file storage functions
- `src/main/settings-manager.ts` — API key getter with env fallback + MCP settings
- `src/main/main.ts` — IPC handlers for key management
- `src/main/preload.ts` — Bridge methods
- `src/renderer/electron.d.ts` — Type definitions
- `src/renderer/components/settings/sections/AuthenticationSettings.tsx` — BuildBuddy API key UI
- `src/renderer/components/settings/sections/DockerSettings.tsx` — MCP server configuration UI
- `src/main/tool-proxy.ts` — Use stored key instead of process.env
- `src/main/docker-sandbox.ts` — Pass key + mount MCP server in containers

## Test plan

- [x] Configure a BuildBuddy API key in Settings > Authentication, verify it's saved to `~/.bismarck/buildbuddy-token.json`
- [x] Enable `bb` proxied tool, run a `bb` command from a Docker agent, verify it receives the API key
- [x] Set the MCP host path in Docker settings, enable it, start a headless agent, verify Claude Code inside the container sees the BuildBuddy MCP server
- [x] Run `npm run build` to verify TypeScript compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)