### PR TITLE
feat: Add agent type selection for standalone and interactive agents

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -13,8 +13,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('reorder-workspaces', workspaceIds),
 
   // Terminal management
-  createTerminal: (workspaceId: string): Promise<string> =>
-    ipcRenderer.invoke('create-terminal', workspaceId),
+  createTerminal: (workspaceId: string, options?: { agentType?: string }): Promise<string> =>
+    ipcRenderer.invoke('create-terminal', workspaceId, options),
   writeTerminal: (terminalId: string, data: string): Promise<void> =>
     ipcRenderer.invoke('write-terminal', terminalId, data),
   resizeTerminal: (
@@ -144,7 +144,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('destroy-headless-agent', taskId, isStandalone),
 
   // Standalone headless agent management
-  startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet', tabId?: string, options?: { planPhase?: boolean }): Promise<{ headlessId: string; workspaceId: string; tabId: string }> =>
+  startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet', tabId?: string, options?: { planPhase?: boolean; agentType?: string }): Promise<{ headlessId: string; workspaceId: string; tabId: string }> =>
     ipcRenderer.invoke('start-standalone-headless-agent', agentId, prompt, model, tabId, options),
   getStandaloneHeadlessAgents: (): Promise<HeadlessAgentInfo[]> =>
     ipcRenderer.invoke('get-standalone-headless-agents'),

--- a/src/main/terminal-queue.ts
+++ b/src/main/terminal-queue.ts
@@ -141,7 +141,8 @@ export function queueTerminalCreation(
  */
 export async function queueTerminalCreationWithSetup(
   workspaceId: string,
-  mainWindow: BrowserWindow | null
+  mainWindow: BrowserWindow | null,
+  options?: { claudeFlags?: string }
 ): Promise<string> {
   // Create socket server for this workspace
   createSocketServer(workspaceId)
@@ -155,7 +156,7 @@ export async function queueTerminalCreationWithSetup(
   setActiveTab(tab.id)
 
   // Queue the terminal creation
-  return queueTerminalCreation(workspaceId, mainWindow)
+  return queueTerminalCreation(workspaceId, mainWindow, options ? { claudeFlags: options.claudeFlags } : undefined)
 }
 
 /**

--- a/src/renderer/components/WorkspaceCard.tsx
+++ b/src/renderer/components/WorkspaceCard.tsx
@@ -128,6 +128,17 @@ export const AgentCard = memo(function AgentCard({
             Headless
           </span>
         )}
+        {agent.agentType && agent.agentType !== 'task' && (
+          <span className={`text-xs px-1.5 py-0.5 rounded flex-shrink-0 ${
+            agent.agentType === 'critic' ? 'bg-amber-500/20 text-amber-400' :
+            agent.agentType === 'architect' ? 'bg-emerald-500/20 text-emerald-400' :
+            agent.agentType === 'manager' ? 'bg-indigo-500/20 text-indigo-400' :
+            agent.agentType === 'discussion' ? 'bg-cyan-500/20 text-cyan-400' :
+            'bg-gray-500/20 text-gray-400'
+          }`}>
+            {agent.agentType.charAt(0).toUpperCase() + agent.agentType.slice(1)}
+          </span>
+        )}
         {isWaiting && (
           <span className="text-xs bg-yellow-500 text-black px-1.5 py-0.5 rounded flex-shrink-0">
             Waiting

--- a/src/renderer/components/WorkspaceModal.tsx
+++ b/src/renderer/components/WorkspaceModal.tsx
@@ -18,9 +18,9 @@ import {
 } from '@/renderer/components/ui/select'
 import { Tooltip } from '@/renderer/components/ui/tooltip'
 import { AgentIcon } from '@/renderer/components/AgentIcon'
-import type { Agent, AgentProvider, ThemeName, Repository } from '@/shared/types'
+import type { Agent, AgentProvider, ThemeName, Repository, StandaloneAgentType } from '@/shared/types'
 import type { AgentIconName } from '@/shared/constants'
-import { themes, agentIcons, agentProviderNames } from '@/shared/constants'
+import { themes, agentIcons, agentProviderNames, STANDALONE_AGENT_TYPES } from '@/shared/constants'
 import { GitBranch, X, FolderOpen } from 'lucide-react'
 
 interface AgentModalProps {
@@ -43,6 +43,7 @@ export function AgentModal({
   const [theme, setTheme] = useState<ThemeName>('gray')
   const [icon, setIcon] = useState<AgentIconName>('beethoven')
   const [provider, setProvider] = useState<AgentProvider>('claude')
+  const [agentType, setAgentType] = useState<StandaloneAgentType | undefined>(undefined)
   const [error, setError] = useState<string | null>(null)
 
   // Git repository detection state
@@ -83,12 +84,14 @@ export function AgentModal({
       setTheme(agent.theme)
       setIcon(agent.icon || 'beethoven')
       setProvider(agent.provider || 'claude')
+      setAgentType(agent.agentType)
     } else {
       setName('')
       setDirectory('')
       setTheme('gray')
       // Random icon for new agents
       setIcon(agentIcons[Math.floor(Math.random() * agentIcons.length)])
+      setAgentType(undefined)
       // Load default provider from settings
       window.electronAPI.getSettings().then(settings => {
         setProvider(settings.defaultProvider || 'claude')
@@ -132,6 +135,7 @@ export function AgentModal({
       theme,
       icon,
       provider,
+      agentType,
       repositoryId: detectedRepo?.id,
     }
 
@@ -214,6 +218,30 @@ export function AgentModal({
               </SelectContent>
             </Select>
           </div>
+          {provider === 'claude' && (
+            <div className="grid gap-2">
+              <Label>Role (optional)</Label>
+              <div className="flex gap-1.5">
+                {STANDALONE_AGENT_TYPES.map((type) => (
+                  <button
+                    key={type.value}
+                    onClick={() => setAgentType(agentType === type.value ? undefined : type.value)}
+                    className={`px-2.5 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                      agentType === type.value
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                    }`}
+                    title={type.description}
+                  >
+                    {type.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Sets a role-specific system prompt when launching this agent. Click again to deselect.
+              </p>
+            </div>
+          )}
           <div className="grid gap-2">
             <Label htmlFor="theme">Theme</Label>
             <div className="flex items-center gap-3">

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -27,7 +27,7 @@ export interface ElectronAPI {
   reorderWorkspaces: (workspaceIds: string[]) => Promise<void>
 
   // Terminal management
-  createTerminal: (workspaceId: string) => Promise<string>
+  createTerminal: (workspaceId: string, options?: { agentType?: string }) => Promise<string>
   writeTerminal: (terminalId: string, data: string) => Promise<void>
   resizeTerminal: (
     terminalId: string,
@@ -115,7 +115,7 @@ export interface ElectronAPI {
   destroyHeadlessAgent: (taskId: string, isStandalone: boolean) => Promise<{ success: boolean; error?: string }>
 
   // Standalone headless agent management
-  startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet' | 'haiku', tabId?: string, options?: { planPhase?: boolean }) => Promise<{ headlessId: string; workspaceId: string; tabId: string }>
+  startStandaloneHeadlessAgent: (agentId: string, prompt: string, model: 'opus' | 'sonnet' | 'haiku', tabId?: string, options?: { planPhase?: boolean; agentType?: string }) => Promise<{ headlessId: string; workspaceId: string; tabId: string }>
   getStandaloneHeadlessAgents: () => Promise<HeadlessAgentInfo[]>
   stopStandaloneHeadlessAgent: (headlessId: string) => Promise<void>
   nudgeHeadlessAgent: (taskId: string, message: string, isStandalone: boolean) => Promise<boolean>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,4 @@
-import type { ThemeName, ThemeColors, AgentProvider } from './types'
+import type { ThemeName, ThemeColors, AgentProvider, StandaloneAgentType } from './types'
 
 // Famous German figure icons for agents
 // Mix of iconic historical figures and modern pop-culture personalities
@@ -79,3 +79,11 @@ export const agentProviderNames: Record<AgentProvider, string> = {
   claude: 'Claude Code',
   codex: 'OpenAI Codex',
 }
+
+// Agent types available for standalone (non-plan) agent selection
+export const STANDALONE_AGENT_TYPES: Array<{ value: StandaloneAgentType; label: string; description: string }> = [
+  { value: 'critic', label: 'Critic', description: 'Reviews code and raises fix-up issues' },
+  { value: 'architect', label: 'Architect', description: 'Decomposes large tasks into subtasks' },
+  { value: 'manager', label: 'Manager', description: 'Triages and routes tasks by complexity' },
+  { value: 'discussion', label: 'Discussion', description: 'Refines requirements through structured Q&A' },
+]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,8 @@
 import type { AgentIconName } from './constants'
 
+// Agent types available for standalone (non-plan) agents
+export type StandaloneAgentType = 'task' | 'critic' | 'manager' | 'architect' | 'discussion'
+
 // Customizable prompt types (available in settings)
 export type CustomizablePromptType = 'orchestrator' | 'planner' | 'discussion' | 'task' | 'standalone_headless' | 'standalone_followup' | 'headless_discussion' | 'critic' | 'manager' | 'architect'
 
@@ -90,6 +93,7 @@ export interface Agent {
   taskId?: string               // Associated task ID
   isHeadless?: boolean          // Running in headless Docker mode (no interactive terminal)
   isStandaloneHeadless?: boolean // Standalone headless agent (not part of a plan)
+  agentType?: StandaloneAgentType // Agent role type (default: task)
   order?: number                 // Display order in sidebar (lower = higher in list)
 }
 
@@ -538,7 +542,7 @@ export interface HeadlessAgentInfo {
   userPrompt?: string  // Raw user-submitted prompt (for Eye modal default view)
   planText?: string  // Plan generated during planning phase (for Eye modal display)
   model?: AgentModel  // Model used for this agent (opus/sonnet/haiku)
-  agentType?: 'task' | 'critic' | 'merge' | 'manager' | 'architect'  // Type of headless agent (default: task)
+  agentType?: 'task' | 'critic' | 'merge' | 'manager' | 'architect' | 'discussion'  // Type of headless agent (default: task)
   defaultBranch?: string  // Base branch this agent was forked from (for ref-based diffing)
 }
 
@@ -556,6 +560,7 @@ export interface SpawningHeadlessInfo {
   position: number            // Grid slot index within the tab
   prompt: string              // Prompt being executed
   model: 'opus' | 'sonnet'    // Model being used
+  agentType?: StandaloneAgentType // Agent role type (default: task)
   startedAt: number           // Timestamp for display purposes
   // Fallback metadata captured at spawn time (for resilient rendering)
   referenceName: string       // Agent name for display


### PR DESCRIPTION
## Summary

- Add role selection (Critic, Architect, Manager, Discussion) to both headless and interactive agent launch flows
- Roles inject a type-specific system prompt via `--append-system-prompt` when launching Claude sessions
- Toggleable role pill buttons in Cmd+K command palette (commands, agent-select, and prompt-input modes)
- Role selector in agent edit modal (WorkspaceModal) for saving a default role per agent
- Colored role badges on agent cards and headless panel headers

## Changes

- **Types**: `StandaloneAgentType` union type, `agentType` field on `Agent`, `SpawningHeadlessInfo`, `HeadlessAgentInfo`
- **Prompt composition**: `buildStandaloneTypedPrompt()` composes role prompt + standalone infrastructure
- **IPC**: `create-terminal` and `start-standalone-headless-agent` accept optional `agentType`
- **UI**: Role pills in CommandSearch, role selector in WorkspaceModal, badges in WorkspaceCard and App headless panels

## Test plan

- [x] Build compiles cleanly (`npm run build`)
- [x] Cmd+K shows role pills (Critic, Architect, Manager, Discussion) — no "Task" default
- [x] Pills toggle on/off correctly
- [x] WorkspaceModal shows role selector for Claude provider agents
- [x] Agent card badge appears/disappears when saving role
- [x] Headless panel headers show colored backgrounds and labels for all types

🤖 Generated with [Claude Code](https://claude.com/claude-code)